### PR TITLE
fix dont crash if readme and authors are empty in case of old modules

### DIFF
--- a/module_info_import/models/module_information.py
+++ b/module_info_import/models/module_information.py
@@ -44,9 +44,9 @@ class ModuleInformation(models.Model):
         vals = {
             "repo_id": repo.id,
             "name": module_name,
-            "description_rst": vals.get("readme", ""),
+            "description": vals["description"],
             "shortdesc": vals["name"],
-            "authors": vals.get("author", ""),
+            "authors": vals["author"],
         }
         module = self.search([("name", "=", module_name), ("partner_id", "=", False)])
         if module:

--- a/module_info_import/models/module_information.py
+++ b/module_info_import/models/module_information.py
@@ -44,9 +44,9 @@ class ModuleInformation(models.Model):
         vals = {
             "repo_id": repo.id,
             "name": module_name,
-            "description_rst": vals["readme"],
+            "description_rst": vals.get("readme", ""),
             "shortdesc": vals["name"],
-            "authors": vals["author"],
+            "authors": vals.get("author", ""),
         }
         module = self.search([("name", "=", module_name), ("partner_id", "=", False)])
         if module:

--- a/module_info_partner/models/module_information.py
+++ b/module_info_partner/models/module_information.py
@@ -8,11 +8,11 @@ class ModuleInformation(models.Model):
 
     shortdesc = fields.Char(string="Human Name", readonly=True, index=True)
     name = fields.Char(readonly=True, index=True)
-    description_rst = fields.Text(readonly=True)
     note = fields.Text(
         string="Note",
         help="Edit this field to store complementary information about the module",
     )
+    description = fields.Html(readonly=True)
     authors = fields.Char(readonly=True, index=True)
     repo_id = fields.Many2one(
         "module.repo", readonly=True, index=True, string="Host Repository"

--- a/module_info_partner/models/module_partner.py
+++ b/module_info_partner/models/module_partner.py
@@ -32,7 +32,7 @@ class ModulePartner(models.Model):
         vals = {
             "name": module_info.get("name"),
             "shortdesc": module_info.get("shortdesc"),
-            "description_rst": module_info.get("description"),
+            "description": module_info.get("description"),
             "authors": module_info.get("author"),
         }
         if module_info["is_custom"]:

--- a/module_info_partner/views/module_information.xml
+++ b/module_info_partner/views/module_information.xml
@@ -91,7 +91,7 @@
                         </page>
                         <page string="Full description">
                             <group>
-                                <field name="description_rst" />
+                                <field name="description" />
                             </group>
                         </page>
                     </notebook>


### PR DESCRIPTION
In case of old modules v8.0 for instance, some fields may not be present.

I import modules from v8 in our erp, and now the update cron crashes.