### PR TITLE
[FIX] Avoid crash of the sync cron when the version is not present in…

### DIFF
--- a/module_info_import/models/module_information.py
+++ b/module_info_import/models/module_information.py
@@ -21,6 +21,10 @@ class ModuleInformation(models.Model):
             f"/odoo-module-tracker/gh-pages/{version}.yml"
         )
         response = requests.get(url)
+        # not all odoo versions are present in the github yaml files we don't
+        # want the sync cron to fail if version is not managed.
+        if response.status_code != 200:
+            return {}
         return yaml.safe_load(response.text)
 
     # called by cron


### PR DESCRIPTION
… the github yaml files

The sync cron is failing since we import modules from a partner using Odoo version 8.

@bguillot @matthieusaison @sebastienbeau 